### PR TITLE
feat: pivot to awesome-cncf collective CNCF intelligence feed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  schedule:
+    - cron: '0 */6 * * *'  # refresh RSS every 6 hours
   workflow_dispatch:
 
 permissions:
@@ -29,6 +31,11 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Generate RSS feed
+        run: node scripts/generate-rss.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .env
+public/rss.xml

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/peoplehub/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>awesome-cncf — CNCF community feed</title>
+    <link rel="alternate" type="application/rss+xml" title="awesome-cncf RSS" href="/peoplehub/rss.xml" />
     <!-- spa-github-pages: decode redirect from 404.html -->
     <script>
       (function(l) {

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/peoplehub/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>peoplehub</title>
+    <title>awesome-cncf — CNCF community feed</title>
     <!-- spa-github-pages: decode redirect from 404.html -->
     <script>
       (function(l) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,18 +15,17 @@
       "devDependencies": {
         "@types/react": "^18.3.1",
         "@types/react-dom": "^18.3.1",
-        "@vitejs/plugin-react": "^4.3.1",
+        "@vitejs/plugin-react": "^6.0.1",
         "autoprefixer": "^10.4.20",
+        "esbuild": "^0.28.0",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.14",
         "typescript": "^5.5.3",
-        "vite": "^5.4.8"
+        "vite": "^8.0.10"
       }
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -36,292 +35,44 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
-      "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.0"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
-      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
-      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
       "cpu": [
         "ppc64"
       ],
@@ -332,13 +83,13 @@
         "aix"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
       "cpu": [
         "arm"
       ],
@@ -349,13 +100,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
       "cpu": [
         "arm64"
       ],
@@ -366,13 +117,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
       "cpu": [
         "x64"
       ],
@@ -383,13 +134,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
       "cpu": [
         "arm64"
       ],
@@ -400,13 +151,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
       "cpu": [
         "x64"
       ],
@@ -417,13 +168,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
       "cpu": [
         "arm64"
       ],
@@ -434,13 +185,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
       "cpu": [
         "x64"
       ],
@@ -451,13 +202,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
       "cpu": [
         "arm"
       ],
@@ -468,13 +219,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
       "cpu": [
         "arm64"
       ],
@@ -485,13 +236,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
       "cpu": [
         "ia32"
       ],
@@ -502,13 +253,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
       "cpu": [
         "loong64"
       ],
@@ -519,13 +270,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
       "cpu": [
         "mips64el"
       ],
@@ -536,13 +287,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
       "cpu": [
         "ppc64"
       ],
@@ -553,13 +304,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
       "cpu": [
         "riscv64"
       ],
@@ -570,13 +321,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
       "cpu": [
         "s390x"
       ],
@@ -587,13 +338,11 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "version": "0.28.0",
       "cpu": [
         "x64"
       ],
@@ -604,13 +353,30 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
       "cpu": [
         "x64"
       ],
@@ -621,13 +387,30 @@
         "netbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
       "cpu": [
         "x64"
       ],
@@ -638,13 +421,30 @@
         "openbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
       "cpu": [
         "x64"
       ],
@@ -655,13 +455,13 @@
         "sunos"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
       "cpu": [
         "arm64"
       ],
@@ -672,13 +472,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
       "cpu": [
         "ia32"
       ],
@@ -689,13 +489,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
       "cpu": [
         "x64"
       ],
@@ -706,13 +506,11 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -720,21 +518,8 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
-    "node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -743,15 +528,11 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -759,10 +540,27 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -775,8 +573,6 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -785,8 +581,6 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -797,40 +591,25 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
-      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
-      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
       "cpu": [
         "arm64"
       ],
@@ -839,12 +618,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
-      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
       "cpu": [
         "arm64"
       ],
@@ -853,12 +635,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
-      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
       "cpu": [
         "x64"
       ],
@@ -867,26 +652,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
-      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
-      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
       "cpu": [
         "x64"
       ],
@@ -895,12 +669,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
-      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
       "cpu": [
         "arm"
       ],
@@ -909,194 +686,133 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
-      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
-      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
-      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
-      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
-      "cpu": [
-        "loong64"
+      "libc": [
+        "musl"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
-      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
-      "cpu": [
-        "loong64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
-      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
-      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
-      "cpu": [
-        "ppc64"
+      "libc": [
+        "glibc"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
-      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
-      "cpu": [
-        "riscv64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
-      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
-      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
-      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
-      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
-      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
       "cpu": [
         "arm64"
       ],
@@ -1105,12 +821,34 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
-      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
       "cpu": [
         "arm64"
       ],
@@ -1119,26 +857,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
-      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
       "cpu": [
         "x64"
       ],
@@ -1147,85 +874,34 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
-      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@types/babel__generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.2"
-      }
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.7",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1235,8 +911,6 @@
     },
     "node_modules/@types/react-dom": {
       "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1244,37 +918,36 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "version": "6.0.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
+        "@rolldown/pluginutils": "1.0.0-rc.7"
       },
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
       }
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1287,15 +960,11 @@
     },
     "node_modules/arg": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
-      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
       "dev": true,
       "funding": [
         {
@@ -1331,8 +1000,6 @@
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
-      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1344,8 +1011,6 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1357,8 +1022,6 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1370,8 +1033,6 @@
     },
     "node_modules/browserslist": {
       "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -1404,8 +1065,6 @@
     },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
-      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1414,8 +1073,6 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001788",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
-      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "dev": true,
       "funding": [
         {
@@ -1435,8 +1092,6 @@
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1460,8 +1115,6 @@
     },
     "node_modules/chokidar/node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1473,25 +1126,14 @@
     },
     "node_modules/commander": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
     },
-    "node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cssesc": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1503,54 +1145,34 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+        "node": ">=8"
       }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.339",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz",
-      "integrity": "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1558,9 +1180,7 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "version": "0.28.0",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1568,38 +1188,39 @@
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1608,8 +1229,6 @@
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1625,8 +1244,6 @@
     },
     "node_modules/fast-glob/node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1638,8 +1255,6 @@
     },
     "node_modules/fastq": {
       "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1648,8 +1263,6 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1661,8 +1274,6 @@
     },
     "node_modules/fraction.js": {
       "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
-      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1690,28 +1301,14 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1723,8 +1320,6 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1736,8 +1331,6 @@
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1749,8 +1342,6 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1765,8 +1356,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1775,8 +1364,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1788,8 +1375,6 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1798,8 +1383,6 @@
     },
     "node_modules/jiti": {
       "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1808,40 +1391,279 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
-    "node_modules/jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
       "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
       "engines": {
-        "node": ">=6"
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1853,15 +1675,11 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -1870,20 +1688,8 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1892,8 +1698,6 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1904,17 +1708,8 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/mz": {
       "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1925,8 +1720,6 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "dev": true,
       "funding": [
         {
@@ -1944,15 +1737,11 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1961,8 +1750,6 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1971,8 +1758,6 @@
     },
     "node_modules/object-hash": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1981,22 +1766,16 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2008,8 +1787,6 @@
     },
     "node_modules/pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2018,8 +1795,6 @@
     },
     "node_modules/pirates": {
       "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
-      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2028,8 +1803,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -2057,8 +1830,6 @@
     },
     "node_modules/postcss-import": {
       "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
-      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2075,8 +1846,6 @@
     },
     "node_modules/postcss-js": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
-      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
       "dev": true,
       "funding": [
         {
@@ -2101,8 +1870,6 @@
     },
     "node_modules/postcss-load-config": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
-      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
       "dev": true,
       "funding": [
         {
@@ -2144,8 +1911,6 @@
     },
     "node_modules/postcss-nested": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
-      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
       "dev": true,
       "funding": [
         {
@@ -2170,8 +1935,6 @@
     },
     "node_modules/postcss-selector-parser": {
       "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2184,15 +1947,11 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true,
       "funding": [
         {
@@ -2212,8 +1971,6 @@
     },
     "node_modules/react": {
       "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -2224,8 +1981,6 @@
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -2235,20 +1990,8 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/react-refresh": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/react-router": {
       "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
       "license": "MIT",
       "dependencies": {
         "@remix-run/router": "1.23.2"
@@ -2262,8 +2005,6 @@
     },
     "node_modules/react-router-dom": {
       "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
       "license": "MIT",
       "dependencies": {
         "@remix-run/router": "1.23.2",
@@ -2279,8 +2020,6 @@
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2289,8 +2028,6 @@
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2302,8 +2039,6 @@
     },
     "node_modules/resolve": {
       "version": "1.22.12",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2324,8 +2059,6 @@
     },
     "node_modules/reusify": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2333,55 +2066,45 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
-      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.1",
-        "@rollup/rollup-android-arm64": "4.60.1",
-        "@rollup/rollup-darwin-arm64": "4.60.1",
-        "@rollup/rollup-darwin-x64": "4.60.1",
-        "@rollup/rollup-freebsd-arm64": "4.60.1",
-        "@rollup/rollup-freebsd-x64": "4.60.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
-        "@rollup/rollup-linux-arm64-musl": "4.60.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
-        "@rollup/rollup-linux-loong64-musl": "4.60.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-musl": "4.60.1",
-        "@rollup/rollup-openbsd-x64": "4.60.1",
-        "@rollup/rollup-openharmony-arm64": "4.60.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
-        "@rollup/rollup-win32-x64-gnu": "4.60.1",
-        "@rollup/rollup-win32-x64-msvc": "4.60.1",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
       "funding": [
         {
@@ -2404,27 +2127,13 @@
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
     },
-    "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -2433,8 +2142,6 @@
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
-      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2456,8 +2163,6 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2469,8 +2174,6 @@
     },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
-      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2507,8 +2210,6 @@
     },
     "node_modules/thenify": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2517,8 +2218,6 @@
     },
     "node_modules/thenify-all": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2530,8 +2229,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2547,8 +2244,6 @@
     },
     "node_modules/tinyglobby/node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2565,8 +2260,6 @@
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2578,8 +2271,6 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2591,15 +2282,19 @@
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2612,8 +2307,6 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -2643,27 +2336,25 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "5.4.21",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "version": "8.0.10",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -2672,23 +2363,33 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.4.0"
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
         "@types/node": {
           "optional": true
         },
-        "less": {
+        "@vitejs/devtools": {
           "optional": true
         },
-        "lightningcss": {
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
           "optional": true
         },
         "sass": {
@@ -2705,15 +2406,25 @@
         },
         "terser": {
           "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
         }
       }
     },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
       "dev": true,
-      "license": "ISC"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "engines": {
+    "node": ">=20.19 <21 || >=22.12"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/package.json
+++ b/package.json
@@ -17,11 +17,12 @@
   "devDependencies": {
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^6.0.1",
     "autoprefixer": "^10.4.20",
+    "esbuild": "^0.28.0",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.5.3",
-    "vite": "^5.4.8"
+    "vite": "^8.0.10"
   }
 }

--- a/scripts/generate-rss.mjs
+++ b/scripts/generate-rss.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * generate-rss.mjs
+ * Fetches recent stars/forks from CNCF community seed users and writes
+ * public/rss.xml. Run as a pre-build step in CI (GITHUB_TOKEN is always
+ * available in Actions). Output lands in dist/ via Vite's public/ copy.
+ */
+
+import { writeFileSync, mkdirSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(__dirname, '..')
+
+const SEED_USERS = [
+  'caniszczyk', 'castrojo', 'thockin', 'bgrant0607', 'jbeda',
+  'brendandburns', 'liggitt', 'kelseyhightower', 'dims', 'nikhita',
+  'deads2k', 'smarterclayton', 'eddiezane', 'lachie83', 'dlorenc',
+  'hawkw', 'jessfraz', 'aojea', 'sttts', 'spiffxp',
+  'vincepri', 'justinsb', 'bobbypage', 'timja', 'ryantking',
+]
+
+const TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || ''
+const HEADERS = {
+  Accept: 'application/vnd.github+json',
+  'User-Agent': 'awesome-cncf-rss/1.0',
+  ...(TOKEN ? { Authorization: `token ${TOKEN}` } : {}),
+}
+
+async function fetchUserEvents(username) {
+  try {
+    const res = await fetch(
+      `https://api.github.com/users/${username}/events/public?per_page=30`,
+      { headers: HEADERS }
+    )
+    if (!res.ok) return []
+    return await res.json()
+  } catch {
+    return []
+  }
+}
+
+function escapeXml(str) {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+function buildRss(items) {
+  const now = new Date().toUTCString()
+  const itemsXml = items.slice(0, 50).map(item => `
+    <item>
+      <title>${escapeXml(item.title)}</title>
+      <link>${escapeXml(item.link)}</link>
+      <description>${escapeXml(item.description)}</description>
+      <pubDate>${new Date(item.date).toUTCString()}</pubDate>
+      <guid isPermaLink="true">${escapeXml(item.link)}</guid>
+    </item>`).join('\n')
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>awesome-cncf — CNCF community feed</title>
+    <link>https://castrojo.github.io/peoplehub/</link>
+    <description>What the CNCF community is starring and forking on GitHub</description>
+    <language>en-us</language>
+    <lastBuildDate>${now}</lastBuildDate>
+    <atom:link href="https://castrojo.github.io/peoplehub/rss.xml" rel="self" type="application/rss+xml"/>
+    <ttl>360</ttl>
+${itemsXml}
+  </channel>
+</rss>`
+}
+
+async function main() {
+  console.log(`Fetching events for ${SEED_USERS.length} seed users…`)
+  if (!TOKEN) console.warn('Warning: no GITHUB_TOKEN — unauthenticated (60 req/hr limit)')
+
+  // Fetch in batches of 5 to avoid secondary rate limiting
+  const allEvents = []
+  for (let i = 0; i < SEED_USERS.length; i += 5) {
+    const batch = SEED_USERS.slice(i, i + 5)
+    const results = await Promise.all(batch.map(fetchUserEvents))
+    results.forEach(evts => allEvents.push(...evts))
+  }
+
+  // Filter to stars and forks only
+  const filtered = allEvents.filter(e => e.type === 'WatchEvent' || e.type === 'ForkEvent')
+
+  // Deduplicate by id
+  const seen = new Set()
+  const deduped = filtered.filter(e => {
+    if (seen.has(e.id)) return false
+    seen.add(e.id)
+    return true
+  })
+
+  // Sort by date descending
+  deduped.sort((a, b) => b.created_at.localeCompare(a.created_at))
+
+  // Build RSS items
+  const items = deduped.map(e => {
+    const repoName = e.repo.name
+    const repoUrl = `https://github.com/${repoName}`
+    const actor = e.actor.login
+    const verb = e.type === 'WatchEvent' ? 'starred' : 'forked'
+    return {
+      title: `${actor} ${verb} ${repoName}`,
+      link: repoUrl,
+      description: `${actor} ${verb} https://github.com/${repoName}`,
+      date: e.created_at,
+    }
+  })
+
+  const xml = buildRss(items)
+
+  mkdirSync(join(ROOT, 'public'), { recursive: true })
+  writeFileSync(join(ROOT, 'public', 'rss.xml'), xml, 'utf8')
+  console.log(`✓ Written public/rss.xml (${items.length} items, ${deduped.length} events)`)
+}
+
+main().catch(err => {
+  console.error('RSS generation failed:', err.message)
+  // Non-fatal — don't fail the build if RSS generation fails
+  process.exit(0)
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,45 +1,31 @@
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
-import { useUsername } from './hooks/useUsername'
-import { useTeamMembers } from './hooks/useTeamMembers'
+import { BrowserRouter, Routes, Route, Navigate, useNavigate } from 'react-router-dom'
 import { useTheme } from './hooks/useTheme'
 import { FeedPage } from './pages/FeedPage'
 import { SetupPage } from './pages/SetupPage'
+import { ProjectsPage } from './pages/ProjectsPage'
 
 function AppRoutes() {
-  const { username, setUsername, clearUsername } = useUsername()
-  const { members, setMembers, clearMembers } = useTeamMembers()
+  const navigate = useNavigate()
   // Ensure theme is applied on mount
   useTheme()
-
-  const isTeamMode = members.length > 0
 
   return (
     <Routes>
       <Route
         path="/"
-        element={
-          isTeamMode
-            ? (
-              <FeedPage
-                teamMembers={members}
-                onChangeSetup={clearMembers}
-              />
-            )
-            : username
-              ? <FeedPage username={username} onChangeSetup={clearUsername} />
-              : <Navigate to="/setup" replace />
-        }
+        element={<FeedPage onGoToSetup={() => navigate('/setup')} />}
       />
       <Route
         path="/setup"
         element={
           <SetupPage
-            onSaveUsername={(name) => { clearMembers(); setUsername(name) }}
-            onSaveTeam={(memberList) => { clearUsername(); setMembers(memberList) }}
-            initialTab={isTeamMode ? 'team' : 'personal'}
+            onSave={() => {
+              // SetupPage handles setToken + navigate internally; this is a no-op shim
+            }}
           />
         }
       />
+      <Route path="/projects" element={<ProjectsPage />} />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   )

--- a/src/components/CategoryNav.tsx
+++ b/src/components/CategoryNav.tsx
@@ -15,7 +15,7 @@ export function CategoryNav({ active, onChange }: CategoryNavProps) {
     <div
       className="flex gap-1.5 overflow-x-auto pb-1"
       style={{ scrollbarWidth: 'none' }}
-      role="tablist"
+      role="group"
       aria-label="Filter by CNCF category"
     >
       {tabs.map(({ label, value }) => {
@@ -23,8 +23,7 @@ export function CategoryNav({ active, onChange }: CategoryNavProps) {
         return (
           <button
             key={label}
-            role="tab"
-            aria-selected={isActive}
+            aria-pressed={isActive}
             onClick={() => onChange(value)}
             className={[
               'shrink-0 px-3 py-1 rounded-full text-xs font-medium transition-colors whitespace-nowrap',

--- a/src/components/CategoryNav.tsx
+++ b/src/components/CategoryNav.tsx
@@ -1,0 +1,42 @@
+import { CNCF_CATEGORIES } from '../lib/cncfData'
+
+interface CategoryNavProps {
+  active: string | null
+  onChange: (cat: string | null) => void
+}
+
+export function CategoryNav({ active, onChange }: CategoryNavProps) {
+  const tabs: Array<{ label: string; value: string | null }> = [
+    { label: 'All', value: null },
+    ...CNCF_CATEGORIES.map((cat) => ({ label: cat, value: cat })),
+  ]
+
+  return (
+    <div
+      className="flex gap-1.5 overflow-x-auto pb-1"
+      style={{ scrollbarWidth: 'none' }}
+      role="tablist"
+      aria-label="Filter by CNCF category"
+    >
+      {tabs.map(({ label, value }) => {
+        const isActive = active === value
+        return (
+          <button
+            key={label}
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onChange(value)}
+            className={[
+              'shrink-0 px-3 py-1 rounded-full text-xs font-medium transition-colors whitespace-nowrap',
+              isActive
+                ? 'bg-accent-emphasis text-white'
+                : 'bg-canvas-subtle text-fg-muted hover:text-fg hover:bg-canvas-inset border border-border',
+            ].join(' ')}
+          >
+            {label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/FeedCard.tsx
+++ b/src/components/FeedCard.tsx
@@ -1,4 +1,5 @@
 import type { FeedItem, RepoMetadata } from '../types/github'
+import { getCNCFProject } from '../lib/cncfData'
 
 interface FeedCardProps {
   item: FeedItem
@@ -68,6 +69,7 @@ function ActorRow({ actors }: { actors: FeedItem['actors'] }) {
 
 export function FeedCard({ item, meta, isSelected = false, index }: FeedCardProps) {
   const isSafe = item.repo.htmlUrl.startsWith('https://github.com/')
+  const cncfProject = getCNCFProject(item.repo.fullName)
 
   return (
     <article
@@ -104,6 +106,23 @@ export function FeedCard({ item, meta, isSelected = false, index }: FeedCardProp
               </span>
             )}
           </div>
+
+          {cncfProject && (
+            <div className="mt-1.5 flex items-center gap-1.5 flex-wrap">
+              <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-semibold bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300">
+                CNCF · {cncfProject.category}
+              </span>
+              {cncfProject.maturity === 'graduated' ? (
+                <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300">
+                  graduated
+                </span>
+              ) : (
+                <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300">
+                  incubating
+                </span>
+              )}
+            </div>
+          )}
 
           {meta?.description && (
             <p className="mt-1 text-sm text-fg-muted line-clamp-2">

--- a/src/components/ToolOfTheDay.tsx
+++ b/src/components/ToolOfTheDay.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react'
+import { CNCF_GRADUATED } from '../lib/cncfData'
+
+function getTodayProject() {
+  const date = new Date().toISOString().slice(0, 10)
+  const hash = date.split('').reduce((acc, ch) => acc + ch.charCodeAt(0), 0)
+  return CNCF_GRADUATED[hash % CNCF_GRADUATED.length]
+}
+
+// No props needed — self-contained
+export function ToolOfTheDay() {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const project = getTodayProject()
+
+  return (
+    <div className="border border-border rounded-lg overflow-hidden mb-4">
+      <button
+        onClick={() => setIsExpanded((prev) => !prev)}
+        className="w-full flex items-center justify-between px-4 py-2 bg-canvas-subtle hover:bg-canvas-inset transition-colors text-left"
+        aria-expanded={isExpanded}
+      >
+        <span className="text-sm font-medium text-fg">🔧 Tool of the Day</span>
+        <span className="text-fg-subtle text-xs select-none">{isExpanded ? '▲' : '▼'}</span>
+      </button>
+
+      {isExpanded && (
+        <div className="px-4 py-3 bg-canvas border-t border-border">
+          <a
+            href={project.homepage}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-base font-semibold text-accent-fg hover:underline"
+          >
+            {project.name}
+          </a>
+
+          <div className="flex items-center gap-2 mt-2 flex-wrap">
+            {/* Category badge */}
+            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-canvas-subtle text-fg-muted border border-border">
+              {project.category}
+            </span>
+
+            {/* Maturity badge */}
+            {project.maturity === 'graduated' ? (
+              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300">
+                graduated
+              </span>
+            ) : (
+              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300">
+                incubating
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/ToolOfTheDay.tsx
+++ b/src/components/ToolOfTheDay.tsx
@@ -2,8 +2,10 @@ import { useState } from 'react'
 import { CNCF_GRADUATED } from '../lib/cncfData'
 
 function getTodayProject() {
-  const date = new Date().toISOString().slice(0, 10)
-  const hash = date.split('').reduce((acc, ch) => acc + ch.charCodeAt(0), 0)
+  const d = new Date()
+  // Use local date (not UTC) so daily rotation matches the user's clock
+  const dateStr = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`
+  const hash = dateStr.split('').reduce((acc, ch) => acc + ch.charCodeAt(0), 0)
   return CNCF_GRADUATED[hash % CNCF_GRADUATED.length]
 }
 

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -1,0 +1,52 @@
+import { useState, useCallback } from 'react'
+import type { AppConfig } from '../types/config'
+import { CONFIG_KEY } from '../types/config'
+
+function readConfig(): AppConfig {
+  try {
+    const raw = localStorage.getItem(CONFIG_KEY)
+    if (raw) return JSON.parse(raw) as AppConfig
+  } catch {
+    // ignore parse errors — return empty config
+  }
+  return {}
+}
+
+function writeConfig(config: AppConfig): void {
+  try {
+    localStorage.setItem(CONFIG_KEY, JSON.stringify(config))
+  } catch {
+    // ignore storage errors (private browsing, quota exceeded, etc.)
+  }
+}
+
+export function useConfig(): {
+  config: AppConfig
+  setToken: (token: string) => void
+  clearToken: () => void
+  isConfigured: boolean
+} {
+  const [config, setConfigState] = useState<AppConfig>(() => readConfig())
+
+  const setToken = useCallback((token: string) => {
+    setConfigState(prev => {
+      const next: AppConfig = { ...prev, token }
+      writeConfig(next)
+      return next
+    })
+  }, [])
+
+  const clearToken = useCallback(() => {
+    setConfigState(prev => {
+      const next: AppConfig = { ...prev }
+      delete next.token
+      writeConfig(next)
+      return next
+    })
+  }, [])
+
+  // Token is optional — the feed works without one, just rate-limited
+  const isConfigured = true
+
+  return { config, setToken, clearToken, isConfigured }
+}

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -2,19 +2,23 @@ import { useState, useCallback } from 'react'
 import type { AppConfig } from '../types/config'
 import { CONFIG_KEY } from '../types/config'
 
-function readConfig(): AppConfig {
+const TOKEN_SESSION_KEY = `${CONFIG_KEY}:token`
+
+function readToken(): string | undefined {
   try {
-    const raw = localStorage.getItem(CONFIG_KEY)
-    if (raw) return JSON.parse(raw) as AppConfig
+    return sessionStorage.getItem(TOKEN_SESSION_KEY) ?? undefined
   } catch {
-    // ignore parse errors — return empty config
+    return undefined
   }
-  return {}
 }
 
-function writeConfig(config: AppConfig): void {
+function writeToken(token: string | undefined): void {
   try {
-    localStorage.setItem(CONFIG_KEY, JSON.stringify(config))
+    if (token) {
+      sessionStorage.setItem(TOKEN_SESSION_KEY, token)
+    } else {
+      sessionStorage.removeItem(TOKEN_SESSION_KEY)
+    }
   } catch {
     // ignore storage errors (private browsing, quota exceeded, etc.)
   }
@@ -26,12 +30,14 @@ export function useConfig(): {
   clearToken: () => void
   isConfigured: boolean
 } {
-  const [config, setConfigState] = useState<AppConfig>(() => readConfig())
+  const [config, setConfigState] = useState<AppConfig>(() => ({
+    token: readToken(),
+  }))
 
   const setToken = useCallback((token: string) => {
     setConfigState(prev => {
-      const next: AppConfig = { ...prev, token }
-      writeConfig(next)
+      const next: AppConfig = { ...prev, token: token || undefined }
+      writeToken(next.token)
       return next
     })
   }, [])
@@ -40,7 +46,7 @@ export function useConfig(): {
     setConfigState(prev => {
       const next: AppConfig = { ...prev }
       delete next.token
-      writeConfig(next)
+      writeToken(undefined)
       return next
     })
   }, [])

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -5,8 +5,12 @@ import { cacheGet, cacheSet, feedCacheKey } from '../lib/cache'
 import { useConfig } from './useConfig'
 import type { CollectiveFeedState, CategoryFilter, FeedItem } from '../types/github'
 
-const FEED_TTL_MS = 6 * 60 * 60 * 1000        // 6 hours
-const COLLECTIVE_CACHE_KEY = feedCacheKey('collective')
+const FEED_TTL_MS = 6 * 60 * 60 * 1000        // 6 hours — max cache age before forced refresh
+const STALE_MS = 60 * 60 * 1000               // 1 hour — trigger background refresh if older
+
+function getCacheKey(token: string | undefined): string {
+  return feedCacheKey(`collective:${token ? 'auth' : 'anon'}`)
+}
 
 const INITIAL_STATE: CollectiveFeedState = {
   items: [],
@@ -29,11 +33,13 @@ export function useFeed(): {
   const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>(null)
   const fetchingRef = useRef(false)
 
-  const fetchFeed = useCallback(async (token: string | undefined) => {
+  const fetchFeed = useCallback(async (token: string | undefined, background = false) => {
     if (fetchingRef.current) return
     fetchingRef.current = true
 
-    setState(prev => ({ ...prev, isLoading: true, error: null }))
+    if (!background) {
+      setState(prev => ({ ...prev, isLoading: true, error: null }))
+    }
 
     try {
       const result = await fetchCollectiveFeed({ token })
@@ -44,14 +50,16 @@ export function useFeed(): {
         isPartial: result.isPartial,
         failedUsers: result.failedUsers,
         fetchedAt: result.fetchedAt,
-        error: null,
+        error: result.rateLimited ? 'rate_limited' : null,
       }
 
-      cacheSet(COLLECTIVE_CACHE_KEY, next)
+      cacheSet(getCacheKey(token), next)
       setState(next)
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error'
-      setState(prev => ({ ...prev, isLoading: false, error: message }))
+      if (!background) {
+        setState(prev => ({ ...prev, isLoading: false, error: message }))
+      }
     } finally {
       fetchingRef.current = false
     }
@@ -62,17 +70,22 @@ export function useFeed(): {
   }, [config.token, fetchFeed])
 
   useEffect(() => {
-    const cached = cacheGet<CollectiveFeedState>(COLLECTIVE_CACHE_KEY, FEED_TTL_MS)
+    const cacheKey = getCacheKey(config.token)
+    const cached = cacheGet<CollectiveFeedState>(cacheKey, FEED_TTL_MS)
 
     if (cached) {
-      // Serve from cache immediately; data is already a CollectiveFeedState snapshot
       setState({ ...cached.data, isLoading: false })
-      // Background refresh not needed — cache is still within TTL
+      // Background stale-while-revalidate: refresh if data is older than STALE_MS
+      const ageMs = cached.ageMs
+      if (ageMs > STALE_MS) {
+        fetchFeed(config.token, /* background */ true)
+      }
     } else {
       fetchFeed(config.token)
     }
+  // Rerun when token changes so cache key and fetch target update accordingly
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])   // run once on mount; refresh() is the explicit re-fetch path
+  }, [config.token])
 
   const filteredItems: FeedItem[] =
     categoryFilter === null

--- a/src/hooks/useFeed.ts
+++ b/src/hooks/useFeed.ts
@@ -1,99 +1,83 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { getReceivedEvents } from '../lib/github'
-import { filterEvents, deduplicateEvents, aggregateEvents } from '../lib/events'
+import { fetchCollectiveFeed } from '../lib/collectiveFeed'
+import { getCNCFCategory } from '../lib/cncfData'
 import { cacheGet, cacheSet, feedCacheKey } from '../lib/cache'
-import { batchGetOrFetch } from '../lib/repoCache'
-import type { FeedItem, FeedResult, RepoMetadata } from '../types/github'
+import { useConfig } from './useConfig'
+import type { CollectiveFeedState, CategoryFilter, FeedItem } from '../types/github'
 
-const FEED_TTL_MS = 6 * 60 * 60 * 1000   // 6 hours
-const STALE_THRESHOLD_MS = 5 * 60 * 60 * 1000 // background refresh at 5h
+const FEED_TTL_MS = 6 * 60 * 60 * 1000        // 6 hours
+const COLLECTIVE_CACHE_KEY = feedCacheKey('collective')
 
-type FeedStatus = 'idle' | 'loading' | 'success' | 'error' | 'rate_limited'
-
-interface UseFeedResult {
-  items: FeedItem[]
-  repoMeta: Map<string, RepoMetadata>
-  status: FeedStatus
-  lastFetchedAt: Date | null
-  isPartial: boolean
-  refresh: () => void
+const INITIAL_STATE: CollectiveFeedState = {
+  items: [],
+  isLoading: false,
+  isPartial: false,
+  failedUsers: [],
+  fetchedAt: null,
+  error: null,
 }
 
-export function useFeed(username: string | null): UseFeedResult {
-  const [items, setItems] = useState<FeedItem[]>([])
-  const [repoMeta, setRepoMeta] = useState<Map<string, RepoMetadata>>(new Map())
-  const [status, setStatus] = useState<FeedStatus>('idle')
-  const [lastFetchedAt, setLastFetchedAt] = useState<Date | null>(null)
-  const [isPartial, setIsPartial] = useState(false)
+export function useFeed(): {
+  state: CollectiveFeedState
+  categoryFilter: CategoryFilter
+  setCategoryFilter: (cat: CategoryFilter) => void
+  refresh: () => void
+  filteredItems: FeedItem[]
+} {
+  const { config } = useConfig()
+  const [state, setState] = useState<CollectiveFeedState>(INITIAL_STATE)
+  const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>(null)
   const fetchingRef = useRef(false)
 
-  const fetchFeed = useCallback(async (uname: string) => {
+  const fetchFeed = useCallback(async (token: string | undefined) => {
     if (fetchingRef.current) return
     fetchingRef.current = true
-    setStatus('loading')
 
-    const result = await getReceivedEvents(uname)
+    setState(prev => ({ ...prev, isLoading: true, error: null }))
 
-    if ('error' in result) {
-      fetchingRef.current = false
-      if (result.error === 'rate_limited') {
-        setStatus('rate_limited')
-      } else {
-        setStatus('error')
+    try {
+      const result = await fetchCollectiveFeed({ token })
+
+      const next: CollectiveFeedState = {
+        items: result.items,
+        isLoading: false,
+        isPartial: result.isPartial,
+        failedUsers: result.failedUsers,
+        fetchedAt: result.fetchedAt,
+        error: null,
       }
-      return
+
+      cacheSet(COLLECTIVE_CACHE_KEY, next)
+      setState(next)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      setState(prev => ({ ...prev, isLoading: false, error: message }))
+    } finally {
+      fetchingRef.current = false
     }
-
-    const filtered = filterEvents(result.data)
-    const deduped = deduplicateEvents(filtered)
-    const feedResult: FeedResult = aggregateEvents(deduped)
-
-    // Batch-fetch repo metadata for all unique repos
-    const repoNames = feedResult.items.map(i => i.repo.fullName)
-    const meta = await batchGetOrFetch(repoNames)
-
-    cacheSet(feedCacheKey(uname), feedResult)
-
-    setItems(feedResult.items)
-    setRepoMeta(meta)
-    setIsPartial(feedResult.isPartial)
-    setLastFetchedAt(new Date(feedResult.fetchedAt))
-    setStatus('success')
-    fetchingRef.current = false
   }, [])
 
   const refresh = useCallback(() => {
-    if (username) fetchFeed(username)
-  }, [username, fetchFeed])
+    fetchFeed(config.token)
+  }, [config.token, fetchFeed])
 
   useEffect(() => {
-    if (!username) {
-      setStatus('idle')
-      setItems([])
-      return
-    }
-
-    const cached = cacheGet<FeedResult>(feedCacheKey(username), FEED_TTL_MS)
+    const cached = cacheGet<CollectiveFeedState>(COLLECTIVE_CACHE_KEY, FEED_TTL_MS)
 
     if (cached) {
-      // Serve from cache immediately
-      setItems(cached.data.items)
-      setIsPartial(cached.data.isPartial)
-      setLastFetchedAt(new Date(cached.data.fetchedAt))
-      setStatus('success')
-
-      // Enrich repo metadata from repoCache (may be cached already)
-      const repoNames = cached.data.items.map(i => i.repo.fullName)
-      batchGetOrFetch(repoNames).then(setRepoMeta)
-
-      // Background refresh if getting stale
-      if (cached.ageMs > STALE_THRESHOLD_MS) {
-        fetchFeed(username)
-      }
+      // Serve from cache immediately; data is already a CollectiveFeedState snapshot
+      setState({ ...cached.data, isLoading: false })
+      // Background refresh not needed — cache is still within TTL
     } else {
-      fetchFeed(username)
+      fetchFeed(config.token)
     }
-  }, [username, fetchFeed])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])   // run once on mount; refresh() is the explicit re-fetch path
 
-  return { items, repoMeta, status, lastFetchedAt, isPartial, refresh }
+  const filteredItems: FeedItem[] =
+    categoryFilter === null
+      ? state.items
+      : state.items.filter(item => getCNCFCategory(item.repo.fullName) === categoryFilter)
+
+  return { state, categoryFilter, setCategoryFilter, refresh, filteredItems }
 }

--- a/src/hooks/useUsername.ts
+++ b/src/hooks/useUsername.ts
@@ -1,33 +1,10 @@
-import { useState, useCallback } from 'react'
-
-const USERNAME_KEY = 'peoplehub:username'
-
+// Backward-compatible shim — username is now always "awesome-cncf" (collective feed).
+// Real config (optional GitHub token) lives in useConfig.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function useUsername() {
-  const [username, setUsernameState] = useState<string | null>(() => {
-    try {
-      return localStorage.getItem(USERNAME_KEY)
-    } catch {
-      return null
-    }
-  })
-
-  const setUsername = useCallback((name: string) => {
-    try {
-      localStorage.setItem(USERNAME_KEY, name)
-    } catch {
-      // storage unavailable — still update state
-    }
-    setUsernameState(name)
-  }, [])
-
-  const clearUsername = useCallback(() => {
-    try {
-      localStorage.removeItem(USERNAME_KEY)
-    } catch {
-      // ignore
-    }
-    setUsernameState(null)
-  }, [])
-
-  return { username, setUsername, clearUsername }
+  return {
+    username: 'awesome-cncf' as const,
+    setUsername: (_: string) => {},
+    clearUsername: () => {},
+  }
 }

--- a/src/lib/cncfData.ts
+++ b/src/lib/cncfData.ts
@@ -2,7 +2,7 @@ export interface CNCFProject {
   repo: string        // "org/name" e.g. "kubernetes/kubernetes"
   name: string        // Display name: "Kubernetes"
   maturity: 'graduated' | 'incubating'
-  category: string    // One of CNCF_CATEGORIES
+  category: CNCFCategory
   homepage: string    // e.g. "https://kubernetes.io"
 }
 
@@ -80,6 +80,6 @@ export function getCNCFProject(repoFullName: string): CNCFProject | undefined {
   return _repoMap.get(repoFullName.toLowerCase())
 }
 
-export function getCNCFCategory(repoFullName: string): string | undefined {
+export function getCNCFCategory(repoFullName: string): CNCFCategory | undefined {
   return getCNCFProject(repoFullName)?.category
 }

--- a/src/lib/cncfData.ts
+++ b/src/lib/cncfData.ts
@@ -1,0 +1,85 @@
+export interface CNCFProject {
+  repo: string        // "org/name" e.g. "kubernetes/kubernetes"
+  name: string        // Display name: "Kubernetes"
+  maturity: 'graduated' | 'incubating'
+  category: string    // One of CNCF_CATEGORIES
+  homepage: string    // e.g. "https://kubernetes.io"
+}
+
+export const CNCF_CATEGORIES = [
+  'Orchestration',
+  'App Delivery',
+  'Observability',
+  'Security',
+  'Networking',
+  'Runtime',
+  'Storage',
+  'AI/ML',
+  'Platform',
+] as const
+
+export type CNCFCategory = (typeof CNCF_CATEGORIES)[number]
+
+export const CNCF_GRADUATED: CNCFProject[] = [
+  { repo: 'kubernetes/kubernetes',                     name: 'Kubernetes',         maturity: 'graduated', category: 'Orchestration', homepage: 'https://kubernetes.io' },
+  { repo: 'prometheus/prometheus',                     name: 'Prometheus',         maturity: 'graduated', category: 'Observability', homepage: 'https://prometheus.io' },
+  { repo: 'envoyproxy/envoy',                          name: 'Envoy',              maturity: 'graduated', category: 'Networking',    homepage: 'https://envoyproxy.io' },
+  { repo: 'coredns/coredns',                           name: 'CoreDNS',            maturity: 'graduated', category: 'Networking',    homepage: 'https://coredns.io' },
+  { repo: 'containerd/containerd',                     name: 'containerd',         maturity: 'graduated', category: 'Runtime',       homepage: 'https://containerd.io' },
+  { repo: 'fluxcd/flux2',                              name: 'Flux',               maturity: 'graduated', category: 'App Delivery',  homepage: 'https://fluxcd.io' },
+  { repo: 'jaegertracing/jaeger',                      name: 'Jaeger',             maturity: 'graduated', category: 'Observability', homepage: 'https://jaegertracing.io' },
+  { repo: 'vitessio/vitess',                           name: 'Vitess',             maturity: 'graduated', category: 'Storage',       homepage: 'https://vitess.io' },
+  { repo: 'open-policy-agent/opa',                     name: 'Open Policy Agent',  maturity: 'graduated', category: 'Security',      homepage: 'https://openpolicyagent.org' },
+  { repo: 'thanos-io/thanos',                          name: 'Thanos',             maturity: 'graduated', category: 'Observability', homepage: 'https://thanos.io' },
+  { repo: 'rook/rook',                                 name: 'Rook',               maturity: 'graduated', category: 'Storage',       homepage: 'https://rook.io' },
+  { repo: 'helm/helm',                                 name: 'Helm',               maturity: 'graduated', category: 'App Delivery',  homepage: 'https://helm.sh' },
+  { repo: 'goharbor/harbor',                           name: 'Harbor',             maturity: 'graduated', category: 'Runtime',       homepage: 'https://goharbor.io' },
+  { repo: 'etcd-io/etcd',                              name: 'etcd',               maturity: 'graduated', category: 'Orchestration', homepage: 'https://etcd.io' },
+  { repo: 'open-telemetry/opentelemetry-collector',    name: 'OpenTelemetry',      maturity: 'graduated', category: 'Observability', homepage: 'https://opentelemetry.io' },
+  { repo: 'argoproj/argo-cd',                          name: 'Argo CD',            maturity: 'graduated', category: 'App Delivery',  homepage: 'https://argoproj.github.io/cd' },
+  { repo: 'falcosecurity/falco',                       name: 'Falco',              maturity: 'graduated', category: 'Security',      homepage: 'https://falco.org' },
+  { repo: 'linkerd/linkerd2',                          name: 'Linkerd',            maturity: 'graduated', category: 'Networking',    homepage: 'https://linkerd.io' },
+  { repo: 'cilium/cilium',                             name: 'Cilium',             maturity: 'graduated', category: 'Networking',    homepage: 'https://cilium.io' },
+  { repo: 'spiffe/spire',                              name: 'SPIRE',              maturity: 'graduated', category: 'Security',      homepage: 'https://spiffe.io' },
+  { repo: 'longhorn/longhorn',                         name: 'Longhorn',           maturity: 'graduated', category: 'Storage',       homepage: 'https://longhorn.io' },
+  { repo: 'kedacore/keda',                             name: 'KEDA',               maturity: 'graduated', category: 'Orchestration', homepage: 'https://keda.sh' },
+  { repo: 'cert-manager/cert-manager',                 name: 'cert-manager',       maturity: 'graduated', category: 'Security',      homepage: 'https://cert-manager.io' },
+  { repo: 'grpc/grpc',                                 name: 'gRPC',               maturity: 'graduated', category: 'Networking',    homepage: 'https://grpc.io' },
+  { repo: 'fluent/fluentd',                            name: 'Fluentd',            maturity: 'graduated', category: 'Observability', homepage: 'https://fluentd.org' },
+  { repo: 'backstage/backstage',                       name: 'Backstage',          maturity: 'graduated', category: 'Platform',      homepage: 'https://backstage.io' },
+  { repo: 'dapr/dapr',                                 name: 'Dapr',               maturity: 'graduated', category: 'Platform',      homepage: 'https://dapr.io' },
+  { repo: 'sigstore/cosign',                           name: 'Sigstore',           maturity: 'graduated', category: 'Security',      homepage: 'https://sigstore.dev' },
+  { repo: 'crossplane/crossplane',                     name: 'Crossplane',         maturity: 'graduated', category: 'Platform',      homepage: 'https://crossplane.io' },
+  { repo: 'kubeflow/kubeflow',                         name: 'KubeFlow',           maturity: 'graduated', category: 'AI/ML',         homepage: 'https://kubeflow.org' },
+]
+
+export const CNCF_INCUBATING: CNCFProject[] = [
+  { repo: 'argoproj/argo-workflows',         name: 'Argo Workflows',   maturity: 'incubating', category: 'App Delivery',  homepage: 'https://argoproj.github.io/workflows' },
+  { repo: 'knative/serving',                 name: 'Knative',          maturity: 'incubating', category: 'App Delivery',  homepage: 'https://knative.dev' },
+  { repo: 'kyverno/kyverno',                 name: 'Kyverno',          maturity: 'incubating', category: 'Security',      homepage: 'https://kyverno.io' },
+  { repo: 'openkruise/kruise',               name: 'OpenKruise',       maturity: 'incubating', category: 'Orchestration', homepage: 'https://openkruise.io' },
+  { repo: 'volcano-sh/volcano',              name: 'Volcano',          maturity: 'incubating', category: 'AI/ML',         homepage: 'https://volcano.sh' },
+  { repo: 'telepresenceio/telepresence',     name: 'Telepresence',     maturity: 'incubating', category: 'App Delivery',  homepage: 'https://telepresence.io' },
+  { repo: 'chaos-mesh/chaos-mesh',           name: 'Chaos Mesh',       maturity: 'incubating', category: 'Platform',      homepage: 'https://chaos-mesh.org' },
+  { repo: 'kubevela/kubevela',               name: 'KubeVela',         maturity: 'incubating', category: 'App Delivery',  homepage: 'https://kubevela.io' },
+  { repo: 'nats-io/nats-server',             name: 'NATS',             maturity: 'incubating', category: 'Networking',    homepage: 'https://nats.io' },
+  { repo: 'cloudevents/spec',                name: 'CloudEvents',      maturity: 'incubating', category: 'Platform',      homepage: 'https://cloudevents.io' },
+  { repo: 'notaryproject/notation',          name: 'Notary',           maturity: 'incubating', category: 'Security',      homepage: 'https://notaryproject.dev' },
+  { repo: 'opencontainers/runc',             name: 'OCI (runc)',       maturity: 'incubating', category: 'Runtime',       homepage: 'https://opencontainers.org' },
+  { repo: 'cni-plugins/cni-plugins',         name: 'CNI',              maturity: 'incubating', category: 'Networking',    homepage: 'https://cni.dev' },
+  { repo: 'in-toto/in-toto',                 name: 'in-toto',          maturity: 'incubating', category: 'Security',      homepage: 'https://in-toto.io' },
+  { repo: 'pixie-io/pixie',                  name: 'Pixie',            maturity: 'incubating', category: 'Observability', homepage: 'https://px.dev' },
+]
+
+export const CNCF_PROJECTS = [...CNCF_GRADUATED, ...CNCF_INCUBATING]
+
+// Build lookup map by repo full name (lowercase for case-insensitive matching)
+const _repoMap = new Map(CNCF_PROJECTS.map(p => [p.repo.toLowerCase(), p]))
+
+export function getCNCFProject(repoFullName: string): CNCFProject | undefined {
+  return _repoMap.get(repoFullName.toLowerCase())
+}
+
+export function getCNCFCategory(repoFullName: string): string | undefined {
+  return getCNCFProject(repoFullName)?.category
+}

--- a/src/lib/collectiveFeed.ts
+++ b/src/lib/collectiveFeed.ts
@@ -11,6 +11,7 @@ export interface CollectiveFeedOptions {
 
 export interface CollectiveFeedResult extends FeedResult {
   failedUsers: string[]
+  rateLimited: boolean
 }
 
 const BATCH_SIZE = 5
@@ -19,14 +20,24 @@ async function fetchUserEvents(
   username: string,
   token: string | undefined,
   pages: number,
-): Promise<{ username: string; events: GitHubEvent[] } | { username: string; failed: true }> {
+): Promise<{ username: string; events: GitHubEvent[]; rateLimited?: boolean } | { username: string; failed: true; rateLimited?: boolean }> {
   const allEvents: GitHubEvent[] = []
 
   for (let page = 1; page <= pages; page++) {
     const result = await getUserEvents(username, token, page)
 
     if ('error' in result) {
-      // Any error for this user: skip them entirely
+      if (result.error === 'rate_limited') {
+        // Return whatever we accumulated so far with rate-limited flag
+        if (allEvents.length > 0) {
+          return { username, events: allEvents, rateLimited: true }
+        }
+        return { username, failed: true, rateLimited: true }
+      }
+      // For other errors: return partial events if we have them, otherwise fail
+      if (allEvents.length > 0) {
+        return { username, events: allEvents }
+      }
       return { username, failed: true }
     }
 
@@ -48,22 +59,34 @@ export async function fetchCollectiveFeed(
   const users = [...SEED_USERS]
   const allEvents: GitHubEvent[] = []
   const failedUsers: string[] = []
+  let rateLimited = false
 
   // Process users in bounded batches of BATCH_SIZE to avoid secondary rate limiting
   for (let i = 0; i < users.length; i += BATCH_SIZE) {
     const batch = users.slice(i, i + BATCH_SIZE)
 
-    const batchResults = await Promise.all(
+    const batchResults = await Promise.allSettled(
       batch.map(username => fetchUserEvents(username, token, pagesPerUser)),
     )
 
-    for (const result of batchResults) {
+    for (const settled of batchResults) {
+      if (settled.status === 'rejected') {
+        // fetchUserEvents itself threw — shouldn't happen but handle defensively
+        continue
+      }
+      const result = settled.value
+      if (result.rateLimited) {
+        rateLimited = true
+      }
       if ('failed' in result) {
         failedUsers.push(result.username)
       } else {
         allEvents.push(...result.events)
       }
     }
+
+    // If rate limited, stop processing further batches
+    if (rateLimited) break
   }
 
   const filtered = filterEvents(allEvents)
@@ -73,5 +96,6 @@ export async function fetchCollectiveFeed(
   return {
     ...feedResult,
     failedUsers,
+    rateLimited,
   }
 }

--- a/src/lib/collectiveFeed.ts
+++ b/src/lib/collectiveFeed.ts
@@ -1,0 +1,77 @@
+import { SEED_USERS } from './seedUsers'
+import { getUserEvents } from './github'
+import { filterEvents, deduplicateEvents, aggregateEvents } from './events'
+import type { GitHubEvent, FeedResult } from '../types/github'
+
+export interface CollectiveFeedOptions {
+  token?: string
+  /** How many pages to fetch per user. Defaults to 1 (no token) or 2 (with token). */
+  pagesPerUser?: number
+}
+
+export interface CollectiveFeedResult extends FeedResult {
+  failedUsers: string[]
+}
+
+const BATCH_SIZE = 5
+
+async function fetchUserEvents(
+  username: string,
+  token: string | undefined,
+  pages: number,
+): Promise<{ username: string; events: GitHubEvent[] } | { username: string; failed: true }> {
+  const allEvents: GitHubEvent[] = []
+
+  for (let page = 1; page <= pages; page++) {
+    const result = await getUserEvents(username, token, page)
+
+    if ('error' in result) {
+      // Any error for this user: skip them entirely
+      return { username, failed: true }
+    }
+
+    allEvents.push(...result.data)
+
+    // Stop paginating early if the page wasn't full
+    if (result.data.length < 100) break
+  }
+
+  return { username, events: allEvents }
+}
+
+export async function fetchCollectiveFeed(
+  options: CollectiveFeedOptions = {},
+): Promise<CollectiveFeedResult> {
+  const { token } = options
+  const pagesPerUser = options.pagesPerUser ?? (token ? 2 : 1)
+
+  const users = [...SEED_USERS]
+  const allEvents: GitHubEvent[] = []
+  const failedUsers: string[] = []
+
+  // Process users in bounded batches of BATCH_SIZE to avoid secondary rate limiting
+  for (let i = 0; i < users.length; i += BATCH_SIZE) {
+    const batch = users.slice(i, i + BATCH_SIZE)
+
+    const batchResults = await Promise.all(
+      batch.map(username => fetchUserEvents(username, token, pagesPerUser)),
+    )
+
+    for (const result of batchResults) {
+      if ('failed' in result) {
+        failedUsers.push(result.username)
+      } else {
+        allEvents.push(...result.events)
+      }
+    }
+  }
+
+  const filtered = filterEvents(allEvents)
+  const deduplicated = deduplicateEvents(filtered)
+  const feedResult = aggregateEvents(deduplicated)
+
+  return {
+    ...feedResult,
+    failedUsers,
+  }
+}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,6 +1,7 @@
 import type { GitHubEvent, RepoMetadata, ApiResult } from '../types/github'
 
 const GITHUB_API = 'https://api.github.com'
+const FETCH_TIMEOUT_MS = 10_000
 
 function getHeaders(): HeadersInit {
   return {
@@ -18,6 +19,24 @@ function parseRetryAfter(headers: Headers): number {
   return 60_000
 }
 
+async function fetchWithTimeout(
+  url: string,
+  options: RequestInit,
+): Promise<Response> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+  try {
+    return await fetch(url, { ...options, signal: controller.signal })
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      throw new Error(`Request timed out after ${FETCH_TIMEOUT_MS}ms`)
+    }
+    throw err
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
 export async function getReceivedEvents(
   username: string,
   maxPages = 3
@@ -29,7 +48,7 @@ export async function getReceivedEvents(
 
     let response: Response
     try {
-      response = await fetch(url, {
+      response = await fetchWithTimeout(url, {
         headers: getHeaders(),
         redirect: 'error',
       })
@@ -72,12 +91,12 @@ export async function getUserEvents(
 
   const headers: HeadersInit = {
     ...getHeaders(),
-    ...(token ? { Authorization: `token ${token}` } : {}),
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
   }
 
   let response: Response
   try {
-    response = await fetch(url, { headers, redirect: 'error' })
+    response = await fetchWithTimeout(url, { headers, redirect: 'error' })
   } catch (err) {
     return { error: 'network', message: String(err) }
   }
@@ -109,7 +128,7 @@ export async function getRepoMetadata(
 
   let response: Response
   try {
-    response = await fetch(url, {
+    response = await fetchWithTimeout(url, {
       headers: getHeaders(),
       redirect: 'error',
     })

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -65,59 +65,19 @@ export async function getReceivedEvents(
 
 export async function getUserEvents(
   username: string,
-  maxPages = 3
+  token?: string,
+  page = 1,
 ): Promise<ApiResult<GitHubEvent[]>> {
-  const allEvents: GitHubEvent[] = []
+  const url = `${GITHUB_API}/users/${encodeURIComponent(username)}/events/public?per_page=100&page=${page}`
 
-  for (let page = 1; page <= maxPages; page++) {
-    const url = `${GITHUB_API}/users/${encodeURIComponent(username)}/events/public?per_page=100&page=${page}`
-
-    let response: Response
-    try {
-      response = await fetch(url, {
-        headers: getHeaders(),
-        redirect: 'error',
-      })
-    } catch (err) {
-      return { error: 'network', message: String(err) }
-    }
-
-    if (response.status === 403 || response.status === 429) {
-      return { error: 'rate_limited', retryAfter: parseRetryAfter(response.headers) }
-    }
-    if (response.status === 404) {
-      return { error: 'not_found' }
-    }
-    if (!response.ok) {
-      return { error: 'unknown', message: `HTTP ${response.status}` }
-    }
-
-    let events: GitHubEvent[]
-    try {
-      events = await response.json() as GitHubEvent[]
-    } catch {
-      return { error: 'unknown', message: 'Failed to parse response JSON' }
-    }
-
-    allEvents.push(...events)
-
-    if (events.length < 100) break
+  const headers: HeadersInit = {
+    ...getHeaders(),
+    ...(token ? { Authorization: `token ${token}` } : {}),
   }
-
-  return { data: allEvents }
-}
-
-export async function getOrgMembers(
-  org: string
-): Promise<ApiResult<string[]>> {
-  const url = `${GITHUB_API}/orgs/${encodeURIComponent(org)}/members?per_page=100`
 
   let response: Response
   try {
-    response = await fetch(url, {
-      headers: getHeaders(),
-      redirect: 'error',
-    })
+    response = await fetch(url, { headers, redirect: 'error' })
   } catch (err) {
     return { error: 'network', message: String(err) }
   }
@@ -132,14 +92,14 @@ export async function getOrgMembers(
     return { error: 'unknown', message: `HTTP ${response.status}` }
   }
 
-  let raw: Array<{ login: string }>
+  let events: GitHubEvent[]
   try {
-    raw = await response.json() as Array<{ login: string }>
+    events = await response.json() as GitHubEvent[]
   } catch {
-    return { error: 'unknown', message: 'Failed to parse org members JSON' }
+    return { error: 'unknown', message: 'Failed to parse events JSON' }
   }
 
-  return { data: raw.map(m => m.login) }
+  return { data: events }
 }
 
 export async function getRepoMetadata(

--- a/src/lib/seedUsers.ts
+++ b/src/lib/seedUsers.ts
@@ -1,0 +1,29 @@
+export const SEED_USERS = [
+  'caniszczyk',      // CNCF CTO
+  'castrojo',        // Universal Blue / CNCF contributor
+  'thockin',         // Google / Kubernetes
+  'bgrant0607',      // Google / Kubernetes
+  'jbeda',           // Kubernetes co-creator
+  'brendandburns',   // Kubernetes co-creator
+  'liggitt',         // Google / Kubernetes
+  'kelseyhightower', // Google / cloud native
+  'dims',            // IBM / CNCF TOC
+  'nikhita',         // CNCF staff / Kubernetes
+  'deads2k',         // Red Hat / Kubernetes
+  'smarterclayton',  // Red Hat / OpenShift
+  'eddiezane',       // CNCF staff
+  'lachie83',        // Microsoft / CNCF
+  'dlorenc',         // Chainguard / Sigstore
+  'hawkw',           // Buoyant / Linkerd
+  'jessfraz',        // Cloud native contributor
+  'aojea',           // Google / Kubernetes networking
+  'sttts',           // Red Hat / Kubernetes
+  'spiffxp',         // Google / Kubernetes testing
+  'vincepri',        // CNCF contributor
+  'justinsb',        // Kubernetes contributor
+  'bobbypage',       // Kubernetes contributor
+  'timja',           // Jenkins / CD Foundation
+  'ryantking',       // Cloud native contributor
+] as const
+
+export type SeedUser = (typeof SEED_USERS)[number]

--- a/src/pages/FeedPage.tsx
+++ b/src/pages/FeedPage.tsx
@@ -1,35 +1,19 @@
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 import { useFeed } from '../hooks/useFeed'
-import { useTeamFeed } from '../hooks/useTeamFeed'
 import { useRateLimit } from '../hooks/useRateLimit'
 import { useTheme } from '../hooks/useTheme'
 import { useKeyboardNav } from '../hooks/useKeyboardNav'
-import { useAutoRefresh, AUTO_REFRESH_INTERVALS, type AutoRefreshInterval } from '../hooks/useAutoRefresh'
 import { FeedList } from '../components/FeedList'
-import { Leaderboard } from '../components/Leaderboard'
 import { RateLimitBanner } from '../components/RateLimitBanner'
+import { CategoryNav } from '../components/CategoryNav'
+import { ToolOfTheDay } from '../components/ToolOfTheDay'
 import { ErrorBoundary } from '../components/ErrorBoundary'
 import { ShortcutsHelp } from '../components/ShortcutsHelp'
-import type { FeedItem, RepoMetadata } from '../types/github'
+import type { RepoMetadata } from '../types/github'
 
-// ── prop shapes ──────────────────────────────────────────────────────────────
-
-interface PersonalFeedPageProps {
-  username: string
-  teamMembers?: never
-  onChangeSetup: () => void
+interface FeedPageProps {
+  onGoToSetup?: () => void
 }
-
-interface TeamFeedPageProps {
-  teamMembers: string[]
-  username?: never
-  onChangeSetup: () => void
-}
-
-type FeedPageProps = PersonalFeedPageProps | TeamFeedPageProps
-
-// ── helpers ──────────────────────────────────────────────────────────────────
 
 function ThemeIcon({ theme }: { theme: string }) {
   if (theme === 'dark') return <>🌙</>
@@ -37,39 +21,36 @@ function ThemeIcon({ theme }: { theme: string }) {
   return <>💻</>
 }
 
-function formatCountdown(seconds: number): string {
-  if (seconds < 60) return `${seconds}s`
-  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`
-}
+// Empty map — collective feed doesn't vend per-repo metadata separately.
+// FeedCard gracefully handles missing meta.
+const EMPTY_REPO_META = new Map<string, RepoMetadata>()
 
-// ── inner component that receives resolved feed data ─────────────────────────
-
-interface FeedViewProps {
-  items: FeedItem[]
-  repoMeta: Map<string, RepoMetadata>
-  status: 'idle' | 'loading' | 'success' | 'error' | 'rate_limited'
-  lastFetchedAt: Date | null
-  isPartial: boolean
-  refresh: () => void
-  label: string          // e.g. "@castrojo" or "Team · 12 members"
-  onChangeSetup: () => void
-}
-
-type ActiveView = 'activity' | 'leaderboard'
-
-function FeedView({
-  items, repoMeta, status, lastFetchedAt, isPartial, refresh,
-  label, onChangeSetup,
-}: FeedViewProps) {
-  const [activeView, setActiveView] = useState<ActiveView>('activity')
+export function FeedPage({ onGoToSetup }: FeedPageProps) {
+  const { state, categoryFilter, setCategoryFilter, refresh, filteredItems } = useFeed()
   const { isRateLimited, retryAfter, setRateLimited, clear: clearRateLimit } = useRateLimit()
   const { theme, cycleTheme } = useTheme()
-  const navigate = useNavigate()
+  const [failedDismissed, setFailedDismissed] = useState(false)
+
+  // Derive a status string compatible with FeedList
+  const status = state.isLoading
+    ? 'loading'
+    : state.error?.toLowerCase().includes('rate')
+    ? 'rate_limited'
+    : state.error
+    ? 'error'
+    : state.fetchedAt
+    ? 'success'
+    : 'idle'
+
+  // Sync rate limit state from derived status
+  if (status === 'rate_limited' && !isRateLimited) {
+    setRateLimited(60_000)
+  }
 
   const { selectedIndex, showHelp, setShowHelp } = useKeyboardNav({
-    itemCount: activeView === 'activity' ? items.length : 0,
+    itemCount: filteredItems.length,
     onOpen: (index) => {
-      const item = items[index]
+      const item = filteredItems[index]
       if (item?.repo.htmlUrl.startsWith('https://github.com/')) {
         window.open(item.repo.htmlUrl, '_blank', 'noopener,noreferrer')
       }
@@ -77,71 +58,30 @@ function FeedView({
     onRefresh: refresh,
   })
 
-  const { isLive, intervalMs, nextRefreshIn, toggleLive, setIntervalMs } = useAutoRefresh({
-    onRefresh: refresh,
-  })
-
-  if (status === 'rate_limited' && !isRateLimited) {
-    setRateLimited(60_000)
-  }
+  const showFailedBanner =
+    !failedDismissed && state.failedUsers.length > 0 && !state.isLoading
 
   return (
     <div className="min-h-screen bg-canvas">
       <header className="border-b border-border sticky top-0 bg-canvas z-10">
         <div className="max-w-2xl mx-auto px-4 py-3 flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <h1 className="font-bold text-fg">peoplehub</h1>
-            <span className="text-xs text-fg-subtle">{label}</span>
+          <div>
+            <h1 className="font-bold text-fg leading-tight">awesome-cncf ✨</h1>
+            <p className="text-xs text-fg-muted leading-tight">
+              what the CNCF community is building
+              {' '}
+              <span className="text-fg-subtle">#puertorico-allhands-2027</span>
+            </p>
           </div>
           <div className="flex items-center gap-3">
-            {lastFetchedAt && (
+            {state.fetchedAt && (
               <span className="hidden sm:block text-xs text-fg-subtle">
-                Updated {lastFetchedAt.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}
+                Updated {new Date(state.fetchedAt).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}
               </span>
             )}
-
-            {/* Live / auto-refresh controls */}
-            <div className="flex items-center gap-1">
-              <button
-                onClick={toggleLive}
-                title={isLive ? 'Disable auto-refresh' : 'Enable auto-refresh (ambient display)'}
-                className={[
-                  'flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium transition-colors',
-                  isLive
-                    ? 'bg-green-500/15 text-green-600 dark:text-green-400'
-                    : 'text-fg-muted hover:text-fg',
-                ].join(' ')}
-              >
-                <span
-                  className={[
-                    'inline-block w-1.5 h-1.5 rounded-full',
-                    isLive ? 'bg-green-500 animate-pulse' : 'bg-fg-subtle',
-                  ].join(' ')}
-                />
-                LIVE
-              </button>
-              {isLive && nextRefreshIn !== null && (
-                <span className="text-xs text-fg-subtle tabular-nums">
-                  {formatCountdown(nextRefreshIn)}
-                </span>
-              )}
-              {isLive && (
-                <select
-                  value={intervalMs}
-                  onChange={e => setIntervalMs(Number(e.target.value) as AutoRefreshInterval)}
-                  className="text-xs text-fg-muted bg-transparent border-none outline-none cursor-pointer"
-                  title="Auto-refresh interval"
-                >
-                  {AUTO_REFRESH_INTERVALS.map(opt => (
-                    <option key={opt.ms} value={opt.ms}>{opt.label}</option>
-                  ))}
-                </select>
-              )}
-            </div>
-
             <button
               onClick={refresh}
-              disabled={status === 'loading'}
+              disabled={state.isLoading}
               className="text-xs text-fg-muted hover:text-fg disabled:opacity-40"
               title="Refresh (r)"
             >
@@ -161,37 +101,15 @@ function FeedView({
             >
               <ThemeIcon theme={theme} />
             </button>
-            <button
-              onClick={() => {
-                onChangeSetup()
-                navigate('/setup')
-              }}
-              className="text-xs text-fg-muted hover:text-fg"
-            >
-              Change
-            </button>
+            {onGoToSetup && (
+              <button
+                onClick={onGoToSetup}
+                className="text-xs text-fg-muted hover:text-fg"
+              >
+                Settings
+              </button>
+            )}
           </div>
-        </div>
-
-        {/* View tab bar */}
-        <div className="max-w-2xl mx-auto px-4 flex gap-0 border-t border-border">
-          {([
-            { id: 'activity',    label: '📋 Activity' },
-            { id: 'leaderboard', label: '🏆 Leaderboard' },
-          ] as const).map(view => (
-            <button
-              key={view.id}
-              onClick={() => setActiveView(view.id)}
-              className={[
-                'px-4 py-2 text-xs font-medium border-b-2 transition-colors',
-                activeView === view.id
-                  ? 'border-accent-emphasis text-fg'
-                  : 'border-transparent text-fg-muted hover:text-fg',
-              ].join(' ')}
-            >
-              {view.label}
-            </button>
-          ))}
         </div>
       </header>
 
@@ -199,86 +117,55 @@ function FeedView({
         {isRateLimited && (
           <RateLimitBanner retryAfter={retryAfter} onDismiss={clearRateLimit} />
         )}
+
+        {showFailedBanner && (
+          <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-border bg-canvas-subtle px-4 py-2 text-sm">
+            <span className="text-fg-muted">
+              ⚠️ Could not reach {state.failedUsers.length} community member{state.failedUsers.length !== 1 ? 's' : ''}
+            </span>
+            <button
+              onClick={() => setFailedDismissed(true)}
+              aria-label="Dismiss"
+              className="text-fg-subtle hover:text-fg text-lg leading-none shrink-0"
+            >
+              ×
+            </button>
+          </div>
+        )}
+
+        <ToolOfTheDay />
+
+        <div className="mb-4">
+          <CategoryNav active={categoryFilter} onChange={setCategoryFilter} />
+        </div>
+
         <ErrorBoundary>
-          {activeView === 'activity' ? (
-            <>
-              <FeedList
-                items={items}
-                repoMeta={repoMeta}
-                status={status}
-                isPartial={isPartial}
-                selectedIndex={selectedIndex}
-                onRetry={refresh}
-              />
-              {items.length > 0 && (
-                <p className="mt-6 text-center text-xs text-fg-subtle">
-                  <kbd className="font-mono">j</kbd>/<kbd className="font-mono">k</kbd> navigate
-                  {' · '}
-                  <kbd className="font-mono">l</kbd> open
-                  {' · '}
-                  <kbd className="font-mono">r</kbd> refresh
-                  {' · '}
-                  <button onClick={() => setShowHelp(true)} className="underline hover:text-fg">
-                    ?
-                  </button>
-                </p>
-              )}
-            </>
-          ) : (
-            <Leaderboard items={items} repoMeta={repoMeta} status={status} />
-          )}
+          <FeedList
+            items={filteredItems}
+            repoMeta={EMPTY_REPO_META}
+            status={status as 'idle' | 'loading' | 'success' | 'error' | 'rate_limited'}
+            isPartial={state.isPartial}
+            selectedIndex={selectedIndex}
+            onRetry={refresh}
+          />
         </ErrorBoundary>
+
+        {filteredItems.length > 0 && (
+          <p className="mt-6 text-center text-xs text-fg-subtle">
+            <kbd className="font-mono">j</kbd>/<kbd className="font-mono">k</kbd> navigate
+            {' · '}
+            <kbd className="font-mono">l</kbd> open
+            {' · '}
+            <kbd className="font-mono">r</kbd> refresh
+            {' · '}
+            <button onClick={() => setShowHelp(true)} className="underline hover:text-fg">
+              ?
+            </button>
+          </p>
+        )}
       </main>
+
       {showHelp && <ShortcutsHelp onClose={() => setShowHelp(false)} />}
     </div>
   )
-}
-
-// ── personal feed wrapper ─────────────────────────────────────────────────────
-
-function PersonalFeedPage({ username, onChangeSetup }: { username: string; onChangeSetup: () => void }) {
-  const { items, repoMeta, status, lastFetchedAt, isPartial, refresh } = useFeed(username)
-  return (
-    <FeedView
-      items={items}
-      repoMeta={repoMeta}
-      status={status}
-      lastFetchedAt={lastFetchedAt}
-      isPartial={isPartial}
-      refresh={refresh}
-      label={`@${username}`}
-      onChangeSetup={onChangeSetup}
-    />
-  )
-}
-
-// ── team feed wrapper ─────────────────────────────────────────────────────────
-
-function TeamFeedPage({ teamMembers, onChangeSetup }: { teamMembers: string[]; onChangeSetup: () => void }) {
-  const { items, repoMeta, status, lastFetchedAt, isPartial, refresh } = useTeamFeed(teamMembers)
-  const label = `Team · ${teamMembers.length} member${teamMembers.length === 1 ? '' : 's'}`
-  return (
-    <FeedView
-      items={items}
-      repoMeta={repoMeta}
-      status={status}
-      lastFetchedAt={lastFetchedAt}
-      isPartial={isPartial}
-      refresh={refresh}
-      label={label}
-      onChangeSetup={onChangeSetup}
-    />
-  )
-}
-
-// ── public export ─────────────────────────────────────────────────────────────
-
-export function FeedPage({ username, teamMembers, onChangeSetup }: FeedPageProps) {
-  if (teamMembers && teamMembers.length > 0) {
-    return <TeamFeedPage teamMembers={teamMembers} onChangeSetup={onChangeSetup} />
-  }
-  if (username) {
-    return <PersonalFeedPage username={username} onChangeSetup={onChangeSetup} />
-  }
-  return null
 }

--- a/src/pages/FeedPage.tsx
+++ b/src/pages/FeedPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { useFeed } from '../hooks/useFeed'
 import { useRateLimit } from '../hooks/useRateLimit'
 import { useTheme } from '../hooks/useTheme'
@@ -9,6 +9,7 @@ import { CategoryNav } from '../components/CategoryNav'
 import { ToolOfTheDay } from '../components/ToolOfTheDay'
 import { ErrorBoundary } from '../components/ErrorBoundary'
 import { ShortcutsHelp } from '../components/ShortcutsHelp'
+import { CNCF_PROJECTS } from '../lib/cncfData'
 import type { RepoMetadata } from '../types/github'
 
 interface FeedPageProps {
@@ -21,9 +22,20 @@ function ThemeIcon({ theme }: { theme: string }) {
   return <>💻</>
 }
 
-// Empty map — collective feed doesn't vend per-repo metadata separately.
-// FeedCard gracefully handles missing meta.
-const EMPTY_REPO_META = new Map<string, RepoMetadata>()
+// Build metadata map from CNCF catalog so descriptions appear for known projects
+function buildCNCFRepoMeta(): Map<string, RepoMetadata> {
+  const map = new Map<string, RepoMetadata>()
+  for (const project of CNCF_PROJECTS) {
+    map.set(project.repo.toLowerCase(), {
+      fullName: project.repo,
+      description: `CNCF ${project.maturity} project · ${project.category}`,
+      language: null,
+      stargazersCount: 0,
+      htmlUrl: project.homepage,
+    })
+  }
+  return map
+}
 
 export function FeedPage({ onGoToSetup }: FeedPageProps) {
   const { state, categoryFilter, setCategoryFilter, refresh, filteredItems } = useFeed()
@@ -31,10 +43,12 @@ export function FeedPage({ onGoToSetup }: FeedPageProps) {
   const { theme, cycleTheme } = useTheme()
   const [failedDismissed, setFailedDismissed] = useState(false)
 
+  const cncfRepoMeta = useMemo(() => buildCNCFRepoMeta(), [])
+
   // Derive a status string compatible with FeedList
   const status = state.isLoading
     ? 'loading'
-    : state.error?.toLowerCase().includes('rate')
+    : state.error === 'rate_limited'
     ? 'rate_limited'
     : state.error
     ? 'error'
@@ -42,10 +56,17 @@ export function FeedPage({ onGoToSetup }: FeedPageProps) {
     ? 'success'
     : 'idle'
 
-  // Sync rate limit state from derived status
-  if (status === 'rate_limited' && !isRateLimited) {
-    setRateLimited(60_000)
-  }
+  // Sync rate limit state from derived status (in effect, not render)
+  useEffect(() => {
+    if (status === 'rate_limited' && !isRateLimited) {
+      setRateLimited(60_000)
+    }
+  }, [status, isRateLimited, setRateLimited])
+
+  // Reset dismissed banner when failed users list changes
+  useEffect(() => {
+    setFailedDismissed(false)
+  }, [state.failedUsers])
 
   const { selectedIndex, showHelp, setShowHelp } = useKeyboardNav({
     itemCount: filteredItems.length,
@@ -142,7 +163,7 @@ export function FeedPage({ onGoToSetup }: FeedPageProps) {
         <ErrorBoundary>
           <FeedList
             items={filteredItems}
-            repoMeta={EMPTY_REPO_META}
+            repoMeta={cncfRepoMeta}
             status={status as 'idle' | 'loading' | 'success' | 'error' | 'rate_limited'}
             isPartial={state.isPartial}
             selectedIndex={selectedIndex}

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -1,0 +1,143 @@
+import { useState, useMemo } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useFeed } from '../hooks/useFeed'
+import { getCNCFProject } from '../lib/cncfData'
+
+interface RepoSummary {
+  fullName: string
+  htmlUrl: string
+  count: number
+  cncfCategory?: string
+  cncfMaturity?: 'graduated' | 'incubating'
+}
+
+function buildRepoList(items: ReturnType<typeof useFeed>['state']['items']): RepoSummary[] {
+  const repoMap = new Map<string, RepoSummary>()
+
+  for (const item of items) {
+    const key = item.repo.fullName.toLowerCase()
+    const existing = repoMap.get(key)
+    if (existing) {
+      existing.count += item.count
+    } else {
+      const cncf = getCNCFProject(item.repo.fullName)
+      repoMap.set(key, {
+        fullName: item.repo.fullName,
+        htmlUrl: item.repo.htmlUrl,
+        count: item.count,
+        cncfCategory: cncf?.category,
+        cncfMaturity: cncf?.maturity,
+      })
+    }
+  }
+
+  return Array.from(repoMap.values()).sort((a, b) => b.count - a.count)
+}
+
+export function ProjectsPage() {
+  const { state } = useFeed()
+  const navigate = useNavigate()
+  const [query, setQuery] = useState('')
+
+  const repos = useMemo(() => buildRepoList(state.items), [state.items])
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return repos
+    const q = query.toLowerCase()
+    return repos.filter((r) => r.fullName.toLowerCase().includes(q))
+  }, [repos, query])
+
+  return (
+    <div className="min-h-screen bg-canvas">
+      <header className="border-b border-border sticky top-0 bg-canvas z-10">
+        <div className="max-w-2xl mx-auto px-4 py-3 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => navigate('/')}
+              className="text-fg-muted hover:text-fg text-sm"
+              aria-label="Back to feed"
+            >
+              ← Back
+            </button>
+            <h1 className="font-bold text-fg">Projects</h1>
+          </div>
+          <span className="text-xs text-fg-subtle">{repos.length} repos</span>
+        </div>
+      </header>
+
+      <main className="max-w-2xl mx-auto px-4 py-6">
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search repos…"
+          className="w-full mb-5 px-3 py-2 text-sm rounded-md border border-border bg-canvas-subtle text-fg placeholder-fg-subtle focus:outline-none focus:ring-2 focus:ring-accent-emphasis"
+          aria-label="Search repositories"
+        />
+
+        {state.isLoading && repos.length === 0 && (
+          <div className="text-center py-16 text-fg-muted">
+            Loading community data…
+          </div>
+        )}
+
+        {!state.isLoading && filtered.length === 0 && (
+          <div className="text-center py-16 text-fg-muted">
+            {query ? 'No repos match your search.' : 'No repos in the collective feed yet.'}
+          </div>
+        )}
+
+        <div className="space-y-2">
+          {filtered.map((repo) => {
+            const isSafe = repo.htmlUrl.startsWith('https://github.com/')
+            return (
+              <div
+                key={repo.fullName}
+                className="bg-canvas border border-border rounded-lg px-4 py-3 flex items-center justify-between gap-3"
+              >
+                <div className="flex-1 min-w-0">
+                  {isSafe ? (
+                    <a
+                      href={repo.htmlUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm font-semibold text-accent-fg hover:underline truncate block"
+                    >
+                      {repo.fullName}
+                    </a>
+                  ) : (
+                    <span className="text-sm font-semibold text-fg truncate block">
+                      {repo.fullName}
+                    </span>
+                  )}
+
+                  {repo.cncfCategory && (
+                    <div className="flex items-center gap-1.5 mt-1 flex-wrap">
+                      <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-semibold bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300">
+                        CNCF · {repo.cncfCategory}
+                      </span>
+                      {repo.cncfMaturity === 'graduated' ? (
+                        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300">
+                          graduated
+                        </span>
+                      ) : (
+                        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300">
+                          incubating
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                <div className="text-xs text-fg-subtle shrink-0 text-right">
+                  <span className="block">⭐ {repo.count}</span>
+                  <span className="text-fg-subtle/60">activity</span>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/pages/SetupPage.tsx
+++ b/src/pages/SetupPage.tsx
@@ -3,14 +3,13 @@ import { useNavigate } from 'react-router-dom'
 import { useConfig } from '../hooks/useConfig'
 
 interface SetupPageProps {
-  // token string on save (empty string = no token) — kept as string for
-  // backward-compat with App.tsx which passes useUsername().setUsername
+  // token string on save (empty string = clear token)
   onSave: (token: string) => void
 }
 
 export function SetupPage({ onSave }: SetupPageProps) {
   const navigate = useNavigate()
-  const { setToken } = useConfig()
+  const { setToken, clearToken } = useConfig()
   const [tokenValue, setTokenValue] = useState('')
 
   const handleSubmit = (e: FormEvent) => {
@@ -18,8 +17,9 @@ export function SetupPage({ onSave }: SetupPageProps) {
     const trimmed = tokenValue.trim()
     if (trimmed) {
       setToken(trimmed)
+    } else {
+      clearToken()
     }
-    // Pass token (or empty string) to parent; parent is a no-op shim now
     onSave(trimmed)
     navigate('/')
   }
@@ -62,7 +62,7 @@ export function SetupPage({ onSave }: SetupPageProps) {
               Without a token, limited to 60 API requests/hour. A read-only public
               token gives 5,000/hour.{' '}
               <a
-                href="https://github.com/settings/tokens/new?description=awesome-cncf&scopes=public_repo"
+                href="https://github.com/settings/tokens/new?description=awesome-cncf"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="underline hover:text-fg"

--- a/src/pages/SetupPage.tsx
+++ b/src/pages/SetupPage.tsx
@@ -1,75 +1,89 @@
-import { useState } from 'react'
+import { useState, type FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { UsernameInput } from '../components/UsernameInput'
-import { TeamInput } from '../components/TeamInput'
+import { useConfig } from '../hooks/useConfig'
 
 interface SetupPageProps {
-  onSaveUsername: (username: string) => void
-  onSaveTeam: (members: string[]) => void
-  initialTab?: 'personal' | 'team'
+  // token string on save (empty string = no token) — kept as string for
+  // backward-compat with App.tsx which passes useUsername().setUsername
+  onSave: (token: string) => void
 }
 
-type Tab = 'personal' | 'team'
-
-export function SetupPage({ onSaveUsername, onSaveTeam, initialTab = 'personal' }: SetupPageProps) {
+export function SetupPage({ onSave }: SetupPageProps) {
   const navigate = useNavigate()
-  const [tab, setTab] = useState<Tab>(initialTab)
+  const { setToken } = useConfig()
+  const [tokenValue, setTokenValue] = useState('')
 
-  const handleSaveUsername = (name: string) => {
-    onSaveUsername(name)
-    navigate('/')
-  }
-
-  const handleSaveTeam = (members: string[]) => {
-    onSaveTeam(members)
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    const trimmed = tokenValue.trim()
+    if (trimmed) {
+      setToken(trimmed)
+    }
+    // Pass token (or empty string) to parent; parent is a no-op shim now
+    onSave(trimmed)
     navigate('/')
   }
 
   return (
     <div className="min-h-screen bg-canvas flex items-center justify-center px-4">
       <div className="w-full max-w-sm">
+        {/* Header */}
         <div className="text-center mb-8">
-          <h1 className="text-2xl font-bold text-fg">peoplehub</h1>
+          <h1 className="text-2xl font-bold text-fg">awesome-cncf ✨</h1>
           <p className="mt-2 text-sm text-fg-muted">
-            Stars and forks from people you follow — nothing else.
+            CNCF community collective intelligence feed
+          </p>
+          <p className="mt-1 text-xs text-fg-muted opacity-60">
+            #puertorico-allhands-2027
           </p>
         </div>
 
-        <div className="flex rounded-md border border-border mb-6 overflow-hidden">
-          <button
-            onClick={() => setTab('personal')}
-            className={[
-              'flex-1 py-2 text-sm font-medium transition-colors',
-              tab === 'personal'
-                ? 'bg-accent-emphasis text-white'
-                : 'text-fg-muted hover:text-fg',
-            ].join(' ')}
-          >
-            Personal feed
-          </button>
-          <button
-            onClick={() => setTab('team')}
-            className={[
-              'flex-1 py-2 text-sm font-medium transition-colors border-l border-border',
-              tab === 'team'
-                ? 'bg-accent-emphasis text-white'
-                : 'text-fg-muted hover:text-fg',
-            ].join(' ')}
-          >
-            Team feed
-          </button>
-        </div>
-
-        {tab === 'personal' ? (
-          <UsernameInput onSave={handleSaveUsername} />
-        ) : (
-          <>
-            <p className="text-xs text-fg-subtle mb-4">
-              See what your teammates have starred and forked recently.
+        {/* Token form */}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label
+              htmlFor="token"
+              className="block text-sm font-medium text-fg mb-1"
+            >
+              GitHub token{' '}
+              <span className="font-normal text-fg-muted">(optional but recommended)</span>
+            </label>
+            <input
+              id="token"
+              type="password"
+              value={tokenValue}
+              onChange={e => setTokenValue(e.target.value)}
+              placeholder="ghp_..."
+              autoComplete="off"
+              spellCheck={false}
+              className="w-full rounded-md border border-border bg-canvas-inset px-3 py-2 text-sm text-fg placeholder:text-fg-subtle focus:outline-none focus:ring-2 focus:ring-accent-emphasis"
+            />
+            <p className="mt-1 text-xs text-fg-muted">
+              Without a token, limited to 60 API requests/hour. A read-only public
+              token gives 5,000/hour.{' '}
+              <a
+                href="https://github.com/settings/tokens/new?description=awesome-cncf&scopes=public_repo"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-fg"
+              >
+                Create one →
+              </a>
             </p>
-            <TeamInput onSave={handleSaveTeam} />
-          </>
-        )}
+          </div>
+
+          <button
+            type="submit"
+            className="w-full rounded-md bg-accent-emphasis px-4 py-2 text-sm font-medium text-white hover:opacity-90"
+          >
+            Enter the feed →
+          </button>
+        </form>
+
+        {/* Easter egg */}
+        <p className="mt-8 text-center text-xs text-fg-muted opacity-40">
+          Powered by CNCF community data · Built with ❤️ on Bluefin
+        </p>
       </div>
     </div>
   )

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,7 +1,7 @@
 // Configuration types for awesome-cncf
 
 export interface AppConfig {
-  token?: string // GitHub personal access token (public_repo read scope)
+  token?: string // GitHub personal access token (no scope needed for rate limit increase)
 }
 
 export const CONFIG_KEY = 'awesome-cncf:config:v1'

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,0 +1,7 @@
+// Configuration types for awesome-cncf
+
+export interface AppConfig {
+  token?: string // GitHub personal access token (public_repo read scope)
+}
+
+export const CONFIG_KEY = 'awesome-cncf:config:v1'

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -75,3 +75,14 @@ export type ApiError =
   | { error: 'unknown'; message: string }
 
 export type ApiResult<T> = { data: T } | ApiError
+
+export interface CollectiveFeedState {
+  items: FeedItem[]
+  isLoading: boolean
+  isPartial: boolean
+  failedUsers: string[]
+  fetchedAt: string | null
+  error: string | null
+}
+
+export type CategoryFilter = string | null  // null = all categories


### PR DESCRIPTION
- Rebrand: title/header → awesome-cncf, mission statement, #puertorico-allhands-2027
- Config layer: useConfig + AppConfig (token-based, no username required)
- SetupPage: optional GitHub token input with rate limit guidance
- Seed users: 25 curated CNCF community GitHub handles
- collectiveFeed: batched event fetch across all seed users, fault tolerant
- cncfData: 30 graduated + 15 incubating CNCF project catalog with categories
- useFeed: pivoted to collective feed, category filter state, 6hr cache
- FeedCard: CNCF badge + maturity badge for ecosystem projects
- CategoryNav: horizontal scrollable category filter tabs
- ToolOfTheDay: date-seeded daily CNCF project widget
- FeedPage: full rewrite with new components, failedUsers banner
- ProjectsPage: searchable repo list from collective feed
- App: /projects route, no username gate (always show feed)
- Deps: vite 8, @vitejs/plugin-react 6, esbuild 0.28

Closes #23, #25, #19, #15
#puertorico-allhands-2027


Assisted-by: Claude Sonnet 4.6 via GitHub Copilot